### PR TITLE
Use rustc_version 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "flier/rust-atomic-traits", branch = "master" }
 cfg-if = "1"
 
 [build-dependencies]
-rustc_version = "0.3"
+rustc_version = "0.4"
 
 [dev-dependencies]
 num-traits = "0.2"


### PR DESCRIPTION
Unfortunately, Cargo views "minor" versions as equivalent to "majors" when the version is 0.x.y
This is consistent with SemVer, which views any patch version as a major version when 0.x.y
So, these versions are not compatible and thus must be bumped manually between 0.x and 0.x+1