### PR TITLE
Use atomic type only if target has it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,12 +378,20 @@ impl_atomic!(AtomicPtr<T>);
 mod integer_atomics {
     use super::*;
 
+    #[cfg(target_has_atomic = "8")]
     impl_atomic!(AtomicI8: i8; bitwise, numops);
+    #[cfg(target_has_atomic = "16")]
     impl_atomic!(AtomicI16: i16; bitwise, numops);
+    #[cfg(target_has_atomic = "32")]
     impl_atomic!(AtomicI32: i32; bitwise, numops);
+    #[cfg(target_has_atomic = "64")]
     impl_atomic!(AtomicI64: i64; bitwise, numops);
+    #[cfg(target_has_atomic = "8")]
     impl_atomic!(AtomicU8: u8; bitwise, numops);
+    #[cfg(target_has_atomic = "16")]
     impl_atomic!(AtomicU16: u16; bitwise, numops);
+    #[cfg(target_has_atomic = "32")]
     impl_atomic!(AtomicU32: u32; bitwise, numops);
+    #[cfg(target_has_atomic = "64")]
     impl_atomic!(AtomicU64: u64; bitwise, numops);
 }


### PR DESCRIPTION
Some targets don't support 64-bit atomics.
For example, when building the crate for `thumbv7em-none-eabihf` (for ARM Cortex M7) it failed with message:

```
   Compiling atomic-traits v0.3.0
error[E0412]: cannot find type `AtomicI64` in this scope
   --> /home/agerasev/.cargo/registry/src/github.com-1ecc6299db9ec823/atomic-traits-0.3.0/src/lib.rs:384:18
    |
384 |       impl_atomic!(AtomicI64: i64; bitwise, numops);
    |                    ^^^^^^^^^ help: a struct with a similar name exists: `AtomicI16`
   --> /rustc/a6d8057f098ab3cebe5a203eb6ebdbd8ce336acc/library/core/src/sync/atomic.rs:2777:1
   ::: /rustc/a6d8057f098ab3cebe5a203eb6ebdbd8ce336acc/library/core/src/sync/atomic.rs:2795:1
    |
    = note: similarly named struct `AtomicI16` defined here

error[E0412]: cannot find type `AtomicU64` in this scope
   --> /home/agerasev/.cargo/registry/src/github.com-1ecc6299db9ec823/atomic-traits-0.3.0/src/lib.rs:388:18
    |
388 |       impl_atomic!(AtomicU64: u64; bitwise, numops);
    |                    ^^^^^^^^^ help: a struct with a similar name exists: `AtomicU16`
   --> /rustc/a6d8057f098ab3cebe5a203eb6ebdbd8ce336acc/library/core/src/sync/atomic.rs:2797:1
   ::: /rustc/a6d8057f098ab3cebe5a203eb6ebdbd8ce336acc/library/core/src/sync/atomic.rs:2815:1
    |
    = note: similarly named struct `AtomicU16` defined here

For more information about this error, try `rustc --explain E0412`.
error: could not compile `atomic-traits` due to 2 previous errors
```
